### PR TITLE
Update state, if Pagesize prop changes

### DIFF
--- a/src/material-table.js
+++ b/src/material-table.js
@@ -42,8 +42,14 @@ class MaterialTable extends React.Component {
   }
 
   UNSAFE_componentWillReceiveProps(nextProps) {
-    const data = this.getData(this.getProps(nextProps));
-    const columns = this.getColumns(this.getProps(nextProps));
+    const calculatedProps = this.getProps(nextProps);
+    const data = this.getData(calculatedProps);
+    const columns = this.getColumns(calculatedProps);
+    if (this.getData(this.props) !== calculatedProps.options.pageSize){
+      this.setState({
+        pageSize: calculatedProps.options.pageSize
+      });
+    }
     this.setState(() => ({ ...columns, ...data }));
   }
 


### PR DESCRIPTION
## Description
If the page size is controlled, it does not get updated, if the prop changes after the initial mounting.
I added a catch for that in componentWillReceiveProps, so that if the prop changes, the state gets updated as well.

## Impacted Areas in Application
- material-table
